### PR TITLE
Fix dev/flex after support for multiple IP addresses

### DIFF
--- a/dev/flex/outputs.tf
+++ b/dev/flex/outputs.tf
@@ -7,6 +7,6 @@ output "interface_ipv4_addresses" {
   description = "List of lists of primary private IPv4 addresses for the interfaces attached to each worker node."
   value = [
     for _, node_info in local.nodes :
-    node_info.network_interfaces[*].private_ip_address
+    node_info.network_interfaces[*].private_ip_addresses[0]
   ]
 }

--- a/dev/flex/templates/values-control-plane.yaml.tftpl
+++ b/dev/flex/templates/values-control-plane.yaml.tftpl
@@ -30,7 +30,7 @@ xrd${i + 1}:
       !
       %{~ for j, interface_info in nodes[node_name].network_interfaces ~}
       interface GigabitEthernet0/0/0/${j}
-       ipv4 address ${interface_info.private_ip_address} 255.255.255.0
+       ipv4 address ${interface_info.private_ip_addresses[0]} 255.255.255.0
       !
       %{~ endfor ~}
     asciiEveryBoot: true

--- a/dev/flex/templates/values-vrouter.yaml.tftpl
+++ b/dev/flex/templates/values-vrouter.yaml.tftpl
@@ -31,7 +31,7 @@ xrd${i + 1}:
       !
       %{~ for j, interface_info in nodes[node_name].network_interfaces ~}
       interface HundredGigE0/0/0/${j}
-       ipv4 address ${interface_info.private_ip_address} 255.255.255.0
+       ipv4 address ${interface_info.private_ip_addresses[0]} 255.255.255.0
       !
       %{~ endfor ~}
     asciiEveryBoot: true


### PR DESCRIPTION
https://github.com/ios-xr/xrd-terraform/pull/4 added support for specifying multiple IP addresses on ENIs.

This broke some `dev/flex`outputs and templates.

### Testing

Manually brought up a `dev/flex` topology, which was successful.