### PR TITLE
Add image_registry variables

### DIFF
--- a/examples/workload/overlay/main.tf
+++ b/examples/workload/overlay/main.tf
@@ -112,12 +112,17 @@ locals {
   trunk_2_subnet_id  = aws_subnet.data[2].id
   access_b_subnet_id = aws_subnet.data[3].id
 
-  default_image_repository = format(
-    "%s.dkr.ecr.%s.amazonaws.com/xrd/xrd-vrouter",
+  default_image_registry = format(
+    "%s.dkr.ecr.%s.amazonaws.com",
     data.aws_caller_identity.current.account_id,
     data.aws_region.current.name,
   )
-  image_repository = coalesce(var.image_repository, local.default_image_repository)
+
+  image_repository = format(
+    "%s/%s",
+    coalesce(var.image_registry, local.default_image_registry),
+    var.image_repository,
+  )
 }
 
 resource "aws_security_group" "data" {

--- a/examples/workload/overlay/variables.tf
+++ b/examples/workload/overlay/variables.tf
@@ -41,10 +41,16 @@ variable "xr_root_password" {
   nullable    = false
 }
 
+variable "image_registry" {
+  description = "Image registry where the XRd container image is hosted."
+  type        = string
+  default     = null
+}
+
 variable "image_repository" {
   description = "Image repository where the XRd container image is hosted."
   type        = string
-  default     = null
+  default     = "xrd/xrd-vrouter"
 }
 
 variable "image_tag" {

--- a/examples/workload/singleton/main.tf
+++ b/examples/workload/singleton/main.tf
@@ -168,7 +168,7 @@ locals {
     data.aws_region.current.name,
   )
 
-  default_image_repository = {
+  default_image_name = {
     "vRouter" : "xrd/xrd-vrouter"
     "ControlPlane" : "xrd/xrd-control-plane"
   }
@@ -176,7 +176,7 @@ locals {
   image_repository = format(
     "%s/%s",
     coalesce(var.image_registry, local.default_image_registry),
-    coalesce(var.image_repository, local.default_image_repository[var.xrd_platform]),
+    coalesce(var.image_repository, local.default_image_name[var.xrd_platform]),
   )
 }
 

--- a/examples/workload/singleton/main.tf
+++ b/examples/workload/singleton/main.tf
@@ -162,17 +162,22 @@ module "node" {
 locals {
   vrouter = var.xrd_platform == "vRouter"
 
-  default_repo_names = {
+  default_image_registry = format(
+    "%s.dkr.ecr.%s.amazonaws.com",
+    data.aws_caller_identity.current.account_id,
+    data.aws_region.current.name,
+  )
+
+  default_image_repository = {
     "vRouter" : "xrd/xrd-vrouter"
     "ControlPlane" : "xrd/xrd-control-plane"
   }
-  default_image_repository = format(
-    "%s.dkr.ecr.%s.amazonaws.com/%s",
-    data.aws_caller_identity.current.account_id,
-    data.aws_region.current.name,
-    local.default_repo_names[var.xrd_platform]
+
+  image_repository = format(
+    "%s/%s",
+    coalesce(var.image_registry, local.default_image_registry),
+    coalesce(var.image_repository, local.default_image_repository[var.xrd_platform]),
   )
-  image_repository = coalesce(var.image_repository, local.default_image_repository)
 }
 
 resource "helm_release" "xrd1" {

--- a/examples/workload/singleton/variables.tf
+++ b/examples/workload/singleton/variables.tf
@@ -53,6 +53,12 @@ variable "xr_root_password" {
   nullable    = false
 }
 
+variable "image_registry" {
+  description = "Image registry where the XRd container image is hosted."
+  type        = string
+  default     = null
+}
+
 variable "image_repository" {
   description = "Image repository where the XRd container image is hosted."
   type        = string


### PR DESCRIPTION
This allows the user to configure `image_repository`, without going through the annoying faff of figuring out their ECR registry URL (which is the default `image_registry`).