### PR TITLE
Use private_ip_list rather than private_ips

### DIFF
--- a/modules/aws/node/main.tf
+++ b/modules/aws/node/main.tf
@@ -145,10 +145,11 @@ resource "aws_network_interface" "this" {
     i => ni
   }
 
-  subnet_id         = each.value.subnet_id
-  private_ips       = each.value.private_ip_addresses
-  security_groups   = each.value.security_groups
-  source_dest_check = false
+  subnet_id               = each.value.subnet_id
+  private_ip_list_enabled = true
+  private_ip_list         = each.value.private_ip_addresses
+  security_groups         = each.value.security_groups
+  source_dest_check       = false
 
   attachment {
     device_index = each.key + 1


### PR DESCRIPTION
This is necessary in order to manage IPs as a sequentially ordered list (i.e. deterministic primary IP).

Refer to https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_interface#example-of-managing-multiple-ips-on-a-network-interface.

"""
In order to manage the private IPs as a sequentially ordered list, configure private_ip_list_enabled to true and use private_ip_list to manage the IPs. This will disable the private_ips and private_ips_count settings, which must be removed from the config file but are still exported.

"""