### PR TITLE
Add ability to specify placement group

### DIFF
--- a/modules/aws/node/main.tf
+++ b/modules/aws/node/main.tf
@@ -138,6 +138,8 @@ resource "aws_instance" "this" {
     Name                                        = var.name
     "kubernetes.io/cluster/${var.cluster_name}" = "owned"
   }
+
+  placement_group = var.placement_group_name
 }
 
 resource "aws_network_interface" "this" {

--- a/modules/aws/node/variables.tf
+++ b/modules/aws/node/variables.tf
@@ -86,6 +86,18 @@ variable "user_data" {
   default     = ""
 }
 
+variable "placement_group_name" {
+  description = <<-EOT
+  Placement group to launch the node into.  Placement groups can be used to
+  align instances to the same (or nearby) compute, thus minimizing expected
+  network latency between the two.   They can also be used to spread the
+  instances apart.
+  By default the node is not added to a placement group.
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "wait" {
   description = "Wait for node readiness"
   type        = bool


### PR DESCRIPTION
Add the ability to specify a placement group to add a node to which is useful to maximize network performance between the EC2 instances.

Refer to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html.

This PR simply makes the change in the Node module, without using it by default in any configuration.  See also #11, which by default creates the placement group in "bootstrap", and uses it in "overlay".