### PR TITLE
Add Github workflows for pre-commit and tests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+---
 name: pre-commit
 
 on:
@@ -16,8 +17,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Setup prerequisites"
+        # yamllint disable rule:line-length
         run: |
           curl -s -L https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | sudo tar xz -C /usr/bin terraform-docs
+        # yamllint enable rule:line-length
       - uses: actions/setup-python@v3
         with:
           cache: "pip"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,4 +27,4 @@ jobs:
           cache: "pip"
       - uses: pre-commit/action@v3.0.0
         with:
-          extra_args: "--hook-stage manual"
+          extra_args: "--hook-stage manual --all-files"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - "main"
-      - "gh-actions"
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   pre-commit:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,4 +26,5 @@ jobs:
         with:
           cache: "pip"
       - uses: pre-commit/action@v3.0.0
-        extra_args: "--hook-stage manual"
+        with:
+          extra_args: "--hook-stage manual"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,21 @@
+name: pre-commit
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  push:
+    branches:
+      - "gh-actions"
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+        with:
+          cache: "pip"
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: "Setup prerequisites"
+        run: |
+          curl https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | sudo tar xz -C /usr/bin terraform-docs
       - uses: actions/setup-python@v3
         with:
           cache: "pip"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: "Setup prerequisites"
         run: |
-          curl https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | sudo tar xz -C /usr/bin terraform-docs
+          curl -s -L https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | sudo tar xz -C /usr/bin terraform-docs
       - uses: actions/setup-python@v3
         with:
           cache: "pip"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,10 @@ on:
       - "main"
   push:
     branches:
+      - "main"
       - "gh-actions"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   pre-commit:
@@ -16,15 +19,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: "Setup prerequisites"
         # yamllint disable rule:line-length
         run: |
           curl -s -L https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin terraform-docs
           curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
         # yamllint enable rule:line-length
+
       - uses: actions/setup-python@v3
         with:
           cache: "pip"
+
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: "--hook-stage manual --all-files"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,9 +19,11 @@ jobs:
       - name: "Setup prerequisites"
         # yamllint disable rule:line-length
         run: |
-          curl -s -L https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | sudo tar xz -C /usr/bin terraform-docs
+          curl -s -L https://github.com/terraform-docs/terraform-docs/releases/download/v0.17.0/terraform-docs-v0.17.0-linux-amd64.tar.gz | tar xz -C /usr/local/bin terraform-docs
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
         # yamllint enable rule:line-length
       - uses: actions/setup-python@v3
         with:
           cache: "pip"
       - uses: pre-commit/action@v3.0.0
+        extra_args: "--hook-stage manual"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+---
 name: tests
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: "Install prerequisites"
-        run: |
-          curl -o terraform.zip https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_linux_amd64.zip
-          unzip -d /usr/bin terraform.zip
+      - name: "Setup Terraform"
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.1"
 
       - name: "Install Python requirements"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths-ignore:
+      - ".gitignore"
+      - ".pre-commit-config.yaml"
+      - "*.md"
+  push:
+    branches:
+      - "gh-actions"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: tests
+    steps:
+      - uses: "actions/checkout@main"
+        with:
+          fetch-depth: 0
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@master"
+        with:
+          python-version: "3.11"
+
+      - name: "Install prerequisites"
+        run: |
+          curl -o terraform.zip https://releases.hashicorp.com/terraform/1.7.0/terraform_1.7.0_linux_amd64.zip
+          unzip -d /usr/bin terraform.zip
+
+      - name: "Install Python requirements"
+        run: |
+          pip install -U pip wheel
+          pip install -r tests/requirements.txt
+
+      - name: Run tests
+        run: pytest tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           terraform_version: "1.7.1"
 
+      - name: "Configure AWS"
+        run: |
+          mkdir ~/.aws
+          echo "[default]\nregion = us-east-1" > ~/.aws/config
+
       - name: "Install Python requirements"
         run: |
           pip install -U pip wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,6 @@ on:
   push:
     branches:
       - "main"
-      - "gh-actions"
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,5 @@
 name: tests
+
 on:
   pull_request:
     branches:
@@ -19,15 +20,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Setup Python"
-        uses: "actions/setup-python@master"
-        with:
-          python-version: "3.11"
-
       - name: "Setup Terraform"
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.7.1"
+
+      - name: "Setup Python"
+        uses: "actions/setup-python@master"
+        with:
+          python-version: "3.11"
+          cache: "pip"
 
       - name: "Install Python requirements"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           terraform_version: "1.7.1"
 
-      - name: "Configure AWS"
-        run: |
-          mkdir ~/.aws
-          echo "[default]\nregion = us-east-1" > ~/.aws/config
-
       - name: "Install Python requirements"
         run: |
           pip install -U pip wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,11 @@ on:
       - "*.md"
   push:
     branches:
+      - "main"
       - "gh-actions"
+  schedule:
+    - cron: "0 0 * * *"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,13 +25,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.7.1"
 
-      - name: "Setup Python"
-        uses: "actions/setup-python@master"
+      - uses: "actions/setup-python@master"
         with:
           python-version: "3.11"
           cache: "pip"

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -47,18 +47,5 @@ terraform destroy
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bastion_instance_id"></a> [bastion\_instance\_id](#output\_bastion\_instance\_id) | Bastion EC2 instance ID |
-| <a name="output_bastion_security_group_id"></a> [bastion\_security\_group\_id](#output\_bastion\_security\_group\_id) | Bastion security group ID |
-| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Cluster name |
-| <a name="output_key_pair_filename"></a> [key\_pair\_filename](#output\_key\_pair\_filename) | Key pair name.<br>This is assigned to the Bastion instance, and may be assigned to worker node instances. |
-| <a name="output_key_pair_name"></a> [key\_pair\_name](#output\_key\_pair\_name) | Key pair name.<br>This is assigned to the Bastion instance, and may be assigned to worker node instances. |
-| <a name="output_kubeconfig_path"></a> [kubeconfig\_path](#output\_kubeconfig\_path) | Path to the generated kubeconfig file |
-| <a name="output_name_prefix"></a> [name\_prefix](#output\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource |
-| <a name="output_node_iam_instance_profile_name"></a> [node\_iam\_instance\_profile\_name](#output\_node\_iam\_instance\_profile\_name) | Worker node IAM instance profile name |
-| <a name="output_node_iam_role_name"></a> [node\_iam\_role\_name](#output\_node\_iam\_role\_name) | Worker node IAM role name |
-| <a name="output_oidc_issuer"></a> [oidc\_issuer](#output\_oidc\_issuer) | Cluster OIDC issuer URL |
-| <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | IAM OIDC provider for the cluster OIDC issuer URL |
-| <a name="output_placement_group_name"></a> [placement\_group\_name](#output\_placement\_group\_name) | Placement group name.<br>Worker node instances may be started in this placement group to cluster instances close together. |
-| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | Subnet IDs of the two private subnets |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
+| <a name="output_bootstrap"></a> [bootstrap](#output\_bootstrap) | Bootstrap module outputs |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/aws/node/outputs.tf
+++ b/modules/aws/node/outputs.tf
@@ -33,7 +33,7 @@ output "isolated_cores_list" {
 }
 
 output "network_interface" {
-  description = "Network interfaces attached to the node"
+  description = "The primary network interface attached to the node"
   value       = aws_network_interface.this
 }
 

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -14,6 +14,10 @@ from .moto_server import MotoServer
 logger = logging.getLogger(__name__)
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption("--region", default="us-east-1")
+
+
 def pytest_configure(config: pytest.Config) -> None:
     # Avoid overly verbose logging.
     logging.getLogger("boto3").setLevel(logging.INFO)
@@ -38,13 +42,25 @@ def moto_server() -> MotoServer:
 
 
 @pytest.fixture(scope="session")
-def ec2(moto_server: MotoServer) -> EC2ServiceResource:
-    return boto3.resource("ec2", endpoint_url=moto_server.endpoint)
+def ec2(
+    request: pytest.FixtureRequest, moto_server: MotoServer,
+) -> EC2ServiceResource:
+    return boto3.resource(
+        "ec2",
+        endpoint_url=moto_server.endpoint,
+        region_name=request.config.getoption("--region"),
+    )
 
 
 @pytest.fixture(scope="session")
-def iam(moto_server: MotoServer) -> IAMServiceResource:
-    return boto3.resource("iam", endpoint_url=moto_server.endpoint)
+def iam(
+    request: pytest.FixtureRequest, moto_server: MotoServer,
+) -> IAMServiceResource:
+    return boto3.resource(
+        "iam",
+        endpoint_url=moto_server.endpoint,
+        region_name=request.config.getoption("--region"),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -53,5 +69,11 @@ def this_dir() -> Path:
 
 
 @pytest.fixture(scope="module")
-def eks_client(moto_server: MotoServer) -> EKSClient:
-    return boto3.client("eks", endpoint_url=moto_server.endpoint)
+def eks_client(
+    request: pytest.FixtureRequest, moto_server: MotoServer,
+) -> EKSClient:
+    return boto3.client(
+        "eks",
+        endpoint_url=moto_server.endpoint,
+        region_name=request.config.getoption("--region"),
+    )

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -46,18 +46,12 @@ def moto_server() -> MotoServer:
 
 
 @pytest.fixture(scope="session")
-def ec2(
-    request: pytest.FixtureRequest,
-    moto_server: MotoServer,
-) -> EC2ServiceResource:
+def ec2(moto_server: MotoServer) -> EC2ServiceResource:
     return boto3.resource("ec2", endpoint_url=moto_server.endpoint)
 
 
 @pytest.fixture(scope="session")
-def iam(
-    request: pytest.FixtureRequest,
-    moto_server: MotoServer,
-) -> IAMServiceResource:
+def iam(moto_server: MotoServer) -> IAMServiceResource:
     return boto3.resource("iam", endpoint_url=moto_server.endpoint)
 
 
@@ -67,8 +61,5 @@ def this_dir() -> Path:
 
 
 @pytest.fixture(scope="module")
-def eks_client(
-    request: pytest.FixtureRequest,
-    moto_server: MotoServer,
-) -> EKSClient:
+def eks_client(moto_server: MotoServer) -> EKSClient:
     return boto3.client("eks", endpoint_url=moto_server.endpoint)

--- a/tests/ut/terraform/bastion/main.tf
+++ b/tests/ut/terraform/bastion/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   endpoints {
     ec2 = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/terraform/data-subnets/main.tf
+++ b/tests/ut/terraform/data-subnets/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   endpoints {
     ec2 = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/terraform/eks/main.tf
+++ b/tests/ut/terraform/eks/main.tf
@@ -3,6 +3,7 @@ provider "aws" {
     ec2 = var.aws_endpoint
     eks = var.aws_endpoint
     iam = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/terraform/irsa/main.tf
+++ b/tests/ut/terraform/irsa/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   endpoints {
     iam = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/terraform/key-pair/main.tf
+++ b/tests/ut/terraform/key-pair/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   endpoints {
     ec2 = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/terraform/node/main.tf
+++ b/tests/ut/terraform/node/main.tf
@@ -3,6 +3,7 @@ provider "aws" {
     ec2 = var.aws_endpoint
     eks = var.aws_endpoint
     iam = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/terraform/vpc/main.tf
+++ b/tests/ut/terraform/vpc/main.tf
@@ -1,6 +1,7 @@
 provider "aws" {
   endpoints {
     ec2 = var.aws_endpoint
+    sts = var.aws_endpoint
   }
 }
 

--- a/tests/ut/test_node.py
+++ b/tests/ut/test_node.py
@@ -27,6 +27,7 @@ from .moto_server import MotoServer
 class Outputs(TerraformOutputs):
     id: str
     instance_type: str
+    network_interface: dict[str, Any]
     private_ip: str
     hugepages_gb: int | None = None
     isolated_cores: str | None = None


### PR DESCRIPTION
Add automation for pre-commit and tests.

Run on PR to main and push to main.  Pre-commit and (unit) tests have no external unpinned dependencies and therefore there should be no need to be scheduled daily/weekly.

Also fix some existing issues with the unit tests (output added to the Node module, and make the unit tests not depend on AWS creds and config) and pre-commit (needed to regenerate Terraform docs).