### PR TITLE
Add support for EKS v1.29

### DIFF
--- a/aws-quickstart
+++ b/aws-quickstart
@@ -37,15 +37,15 @@ OPTIONS:
             Destroy the workload and infrastructure.
 
     --kubernetes-version
-            Kubernetes version to use.  This must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28
-            (default: 1.28).
+            Kubernetes version to use.  This must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29
+            (default: 1.29).
 EOF
 }
 
 # Default arguments.
 AMI_ID=""
 DESTROY=""
-KUBERNETES_VERSION="1.28"
+KUBERNETES_VERSION="1.29"
 XR_USERNAME=""
 XR_PASSWORD=""
 
@@ -94,8 +94,9 @@ if [ "${KUBERNETES_VERSION}" != "1.23" ] &&
    [ "${KUBERNETES_VERSION}" != "1.25" ] &&
    [ "${KUBERNETES_VERSION}" != "1.26" ] &&
    [ "${KUBERNETES_VERSION}" != "1.27" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.28" ]; then
-    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28"
+   [ "${KUBERNETES_VERSION}" != "1.28" ] &&
+   [ "${KUBERNETES_VERSION}" != "1.29" ]; then
+    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29"
     ERROR=1
 fi
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -40,25 +40,12 @@ terraform destroy
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.28"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.29"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bastion_instance_id"></a> [bastion\_instance\_id](#output\_bastion\_instance\_id) | Bastion EC2 instance ID |
-| <a name="output_bastion_security_group_id"></a> [bastion\_security\_group\_id](#output\_bastion\_security\_group\_id) | Bastion security group ID |
-| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Cluster name |
-| <a name="output_key_pair_filename"></a> [key\_pair\_filename](#output\_key\_pair\_filename) | Key pair name.<br>This is assigned to the Bastion instance, and may be assigned to worker node instances. |
-| <a name="output_key_pair_name"></a> [key\_pair\_name](#output\_key\_pair\_name) | Key pair name.<br>This is assigned to the Bastion instance, and may be assigned to worker node instances. |
-| <a name="output_kubeconfig_path"></a> [kubeconfig\_path](#output\_kubeconfig\_path) | Path to the generated kubeconfig file |
-| <a name="output_name_prefix"></a> [name\_prefix](#output\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource |
-| <a name="output_node_iam_instance_profile_name"></a> [node\_iam\_instance\_profile\_name](#output\_node\_iam\_instance\_profile\_name) | Worker node IAM instance profile name |
-| <a name="output_node_iam_role_name"></a> [node\_iam\_role\_name](#output\_node\_iam\_role\_name) | Worker node IAM role name |
-| <a name="output_oidc_issuer"></a> [oidc\_issuer](#output\_oidc\_issuer) | Cluster OIDC issuer URL |
-| <a name="output_oidc_provider"></a> [oidc\_provider](#output\_oidc\_provider) | IAM OIDC provider for the cluster OIDC issuer URL |
-| <a name="output_placement_group_name"></a> [placement\_group\_name](#output\_placement\_group\_name) | Placement group name.<br>Worker node instances may be started in this placement group to cluster instances close together. |
-| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | Subnet IDs of the two private subnets |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
+| <a name="output_bootstrap"></a> [bootstrap](#output\_bootstrap) | Bootstrap module outputs |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -10,6 +10,6 @@ variable "name_prefix" {
 variable "cluster_version" {
   description = "Cluster version"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
   nullable    = false
 }

--- a/modules/aws/eks-config/data.tf
+++ b/modules/aws/eks-config/data.tf
@@ -3,5 +3,5 @@ data "aws_iam_policy" "ebs_csi_driver_policy" {
 }
 
 data "http" "multus_yaml" {
-  url = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/multus/v3.7.2-eksbuild.1/aws-k8s-multus.yaml"
+  url = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/multus/v4.0.2-eksbuild.1/multus-daemonset-thick.yml"
 }

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -1,5 +1,5 @@
 variable "cluster_version" {
-  description = "Kubernetes `<major>.<minor>` version to use for the EKS cluster (e.g. `1.28`)"
+  description = "Desired Kubernetes version for the cluster"
   type        = string
   nullable    = false
 }

--- a/tests/ut/terraform/eks/variables.tf
+++ b/tests/ut/terraform/eks/variables.tf
@@ -5,7 +5,7 @@ variable "aws_endpoint" {
 }
 
 variable "cluster_version" {
-  description = "Kubernetes `<major>.<minor>` version to use for the EKS cluster (e.g. `1.28`)"
+  description = "Desired Kubernetes version for the cluster"
   type        = string
   nullable    = false
 }

--- a/tests/ut/test_eks.py
+++ b/tests/ut/test_eks.py
@@ -101,7 +101,7 @@ def security_group(ec2: EC2ServiceResource, vpc: Vpc) -> SecurityGroup:
 @pytest.fixture
 def base_vars(subnet1: Subnet, subnet2: Subnet) -> dict[str, Any]:
     return {
-        "cluster_version": "1.28",
+        "cluster_version": "1.29",
         "name": str(uuid.uuid4()),
         "subnet_ids": [subnet1.id, subnet2.id],
     }
@@ -123,7 +123,14 @@ def test_defaults(
 
 @pytest.mark.parametrize(
     "cluster_version",
-    ("1.23", "1.24", "1.25", "1.26", "1.27"),
+    (
+        "1.23",
+        "1.24",
+        "1.25",
+        "1.26",
+        "1.27",
+        "1.28",
+    ),
 )
 def test_cluster_version(
     eks_client: EKSClient,


### PR DESCRIPTION
Add support for EKS v1.29.

Notably: upgrade Multus to v4, due to an incompatibility between the VPC CNI v1.16.0 (currently the default for EKS v1.29) and Multus prior to major v4.