### PR TITLE
Add variable to choose two AZs in which to launch the cluster

### DIFF
--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -40,6 +40,7 @@ terraform destroy
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.29"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 

--- a/examples/bootstrap/main.tf
+++ b/examples/bootstrap/main.tf
@@ -10,7 +10,7 @@ provider "aws" {
 module "bootstrap" {
   source = "../../modules/aws/bootstrap"
 
-  azs             = slice(data.aws_availability_zones.available.names, 0, 2)
+  azs             = coalesce(var.azs, slice(data.aws_availability_zones.available.names, 0, 2))
   cluster_version = var.cluster_version
   name_prefix     = var.name_prefix
 }

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -7,6 +7,22 @@ variable "name_prefix" {
   default     = null
 }
 
+variable "azs" {
+  description = <<-EOT
+  List of exactly two availability zones in the currently configured AWS region.
+  A private subnet and a public subnet is created in each of these availability zones.
+  Each cluster node is launched in one of the private subnets.
+  If null, then the first two availability zones in the currently configured AWS region is used.
+  EOT
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition     = try(length(var.azs) == 2, var.azs == null)
+    error_message = "Must provide exactly two availability zones."
+  }
+}
+
 variable "cluster_version" {
   description = "Cluster version"
   type        = string


### PR DESCRIPTION
Expose a Bootstrap configuration variable to allow the user to choose which two AZs they want to launch the cluster in.

Retain the default behaviour of selecting the first two availabe AZs in the currently configured region. 