### PR TITLE
Ignore changes to node secondary IP addresses

### DIFF
--- a/modules/aws/node/main.tf
+++ b/modules/aws/node/main.tf
@@ -127,6 +127,9 @@ resource "aws_instance" "this" {
       Try using a different instance type, or set 'var.isolated_cores' or 'var.xrd_vr_cpuset' to an appropriate value.
       EOT
     }
+
+    # Secondary IP addresses are assigned to the instance by the VPC CNI.
+    ignore_changes = ["secondary_private_ips"]
   }
 
   ami                         = var.ami
@@ -255,7 +258,10 @@ resource "kubernetes_job" "wait" {
   }
 
   timeouts {
-    create = "5m"
+    # If using the XRd-compatible AMI we must wait for the XRd bootstrap
+    # script, the EKS bootstrap script, and reboot.  This is a bit of a
+    # guessing game but 10 minutes should be more than enough.
+    create = "10m"
   }
 
   wait_for_completion = true


### PR DESCRIPTION
The VPC CNI assigns secondary IP addresses to the EC2 instance.  These are then allocated to a Pod at CNI ADD - this enables Pod <-> Pod connectivity between Pods on different EC2 instances (VPC knows to send traffic to the destination Pod to the correct EC2 instance).

Terraform should therefore not try and drift-correct secondary IP addresses.

We have observed this has a notable impact on the HA app example:
- The VPC CNI assigns a secondary IP address to the EC2 instance; this is then given to the CoreDNS Pod.
- This secondary IP address is removed from the instance by Terraform drift-correction.
- Pods on other nodes now cannot talk to the DNS server.  Pods on the same node can - and kubelet on the same node can, so this is not auto-corrected by a liveness probe.
- This affects the HA app and not other examples, because the HA app uses normal Kubernetes networking for DNS.

We are seeing this in automation, because the Kubernetes Jobs which wait for node readiness intermittently timeout, resulting in Terraform retries which enacts this drift-correction.  i.e., the current 5 minute timeout for node readiness is not enough - so also bump this to 10 minutes.