### PR TITLE
Fix deprecation warning in node module

### DIFF
--- a/modules/aws/node/main.tf
+++ b/modules/aws/node/main.tf
@@ -129,7 +129,7 @@ resource "aws_instance" "this" {
     }
 
     # Secondary IP addresses are assigned to the instance by the VPC CNI.
-    ignore_changes = ["secondary_private_ips"]
+    ignore_changes = [secondary_private_ips]
   }
 
   ami                         = var.ami


### PR DESCRIPTION
Collateral of #17.

```
Warning: Quoted references are deprecated
│ 
│   on ../../../xrd-terraform/modules/aws/node/main.tf line 134, in resource "aws_instance" "this":
│  134:     ignore_changes = ["secondary_private_ips"]
│ 
│ In this context, references are expected literally rather than in quotes. Terraform 0.11 and earlier required quotes, but quoted references are now deprecated and will be removed in a future version of Terraform. Remove the quotes surrounding this reference to silence this warning. 
```

Fix this by removing the quotes as suggested.