### PR TITLE
Expose Bastion remote access CIDR in Bootstrap module

### DIFF
--- a/modules/aws/bootstrap/main.tf
+++ b/modules/aws/bootstrap/main.tf
@@ -64,10 +64,11 @@ resource "null_resource" "kubeconfig" {
 module "bastion" {
   source = "../../../modules/aws/bastion"
 
-  instance_type = "t3.nano"
-  key_name      = module.key_pair.key_name
-  name          = "${local.name_prefix}-bastion"
-  subnet_id     = module.vpc.public_subnet_ids[0]
+  instance_type      = "t3.nano"
+  key_name           = module.key_pair.key_name
+  name               = "${local.name_prefix}-bastion"
+  remote_access_cidr = var.bastion_remote_access_cidr_blocks
+  subnet_id          = module.vpc.public_subnet_ids[0]
 }
 
 resource "aws_iam_role" "node" {

--- a/modules/aws/bootstrap/variables.tf
+++ b/modules/aws/bootstrap/variables.tf
@@ -8,6 +8,12 @@ variable "azs" {
   nullable    = false
 }
 
+variable "bastion_remote_access_cidr_blocks" {
+  description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
+  type        = list(string)
+  default     = null
+}
+
 variable "cluster_version" {
   description = "Cluster version"
   type        = string


### PR DESCRIPTION
The Bastion module exports a `remote_access_cidr` variable which is a list of CIDR blocks allowed to SSH to the Bastion (enforced by a security group rule in the Bastion security group).

Re-export this in the Bootstrap module, so end-users of the Bootstrap module can easily customize this.