### PR TITLE
Add EKS v1.30 support

### DIFF
--- a/aws-quickstart
+++ b/aws-quickstart
@@ -37,15 +37,15 @@ OPTIONS:
             Destroy the workload and infrastructure.
 
     --kubernetes-version
-            Kubernetes version to use.  This must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29
-            (default: 1.29).
+            Kubernetes version to use.  This must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30
+            (default: 1.30).
 EOF
 }
 
 # Default arguments.
 AMI_ID=""
 DESTROY=""
-KUBERNETES_VERSION="1.29"
+KUBERNETES_VERSION="1.30"
 XR_USERNAME=""
 XR_PASSWORD=""
 
@@ -95,8 +95,9 @@ if [ "${KUBERNETES_VERSION}" != "1.23" ] &&
    [ "${KUBERNETES_VERSION}" != "1.26" ] &&
    [ "${KUBERNETES_VERSION}" != "1.27" ] &&
    [ "${KUBERNETES_VERSION}" != "1.28" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.29" ]; then
-    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29"
+   [ "${KUBERNETES_VERSION}" != "1.29" ] &&
+   [ "${KUBERNETES_VERSION}" != "1.30" ]; then
+    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30"
     ERROR=1
 fi
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -41,7 +41,7 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.29"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.30"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 
 ## Outputs

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -26,6 +26,6 @@ variable "azs" {
 variable "cluster_version" {
   description = "Cluster version"
   type        = string
-  default     = "1.29"
+  default     = "1.30"
   nullable    = false
 }

--- a/tests/ut/test_eks.py
+++ b/tests/ut/test_eks.py
@@ -101,7 +101,7 @@ def security_group(ec2: EC2ServiceResource, vpc: Vpc) -> SecurityGroup:
 @pytest.fixture
 def base_vars(subnet1: Subnet, subnet2: Subnet) -> dict[str, Any]:
     return {
-        "cluster_version": "1.29",
+        "cluster_version": "1.30",
         "name": str(uuid.uuid4()),
         "subnet_ids": [subnet1.id, subnet2.id],
     }
@@ -130,6 +130,7 @@ def test_defaults(
         "1.26",
         "1.27",
         "1.28",
+        "1.29",
     ),
 )
 def test_cluster_version(


### PR DESCRIPTION
Add support for EKS v1.30.

- `aws-quickstart` script updated to allow 1.30.
- Default version used by the eks-cluster module is changed 1.30.
- MUT updated appropriately.