### PR TITLE
Bootstrap: require user to pass Bastion remote access CIDRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ required:
         created the repository and upload the image.
      3. Example: `./publish-ecr xrd-vrouter-container-x86.7.9.1.tgz`
   2. Run the `aws-quickstart` script.
-     1. This has two mandatory arguments, the username and password to be
-        used for the XRd root user.
+     1. This has three mandatory arguments: the username and password to be
+        used for the XRd root user, and a comma-separated list of IPv4 CIDR
+        blocks to allow SSH access to the Bastion instance.
      2. This will first build an AMI using the
         [XRd Packer](https://github.com/ios-xr/xrd-packer) templates if one
         is not detected.
-     3. Example: `./aws-quickstart -u user -p password`
+     3. Example: `./aws-quickstart -u user -p password -b 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`
 
 This will bring up an EKS cluster called 'xrd-cluster', some worker nodes,
 and a dummy topology with a pair of back-to-back XRd instances running an
@@ -140,6 +141,13 @@ terraform -chdir=examples/bootstrap init
 terraform -chdir=examples/bootstrap apply
 ```
 
+This accepts a number of input variables described in
+[`variables.tf`](/examples/bootstrap/variables.tf).  In particular, the
+`bastion_remote_access_cidr_blocks` variable is required, which is a list of
+IPv4 CIDR blocks to allow SSH access to the Bastion instance.  Pass `null` to
+prevent access to the Bastion instance, or `["0.0.0.0/0"]` to allow SSH access
+from any IPv4 address.
+
 Terraform will show you a changeset and ask you to confirm that it should
 proceed.  It takes around 15 minutes to bring up the configuration.
 
@@ -194,7 +202,7 @@ When you've finished with the topology, it can be torn down with:
 ```
 terraform -chdir=examples/overlay/workload destroy -var-file=$PWD/vars.tfvars
 terraform -chdir=examples/overlay/infra destroy
-terraform -chdir=examples/bootstrap destroy
+terraform -chdir=examples/bootstrap destroy -var=bastion_remote_access_cidr_blocks=null
 ```
 
 N.B. It is recommended to pass the same configuration to `terraform destroy`

--- a/aws-quickstart
+++ b/aws-quickstart
@@ -8,7 +8,7 @@ set -o pipefail
 usage()  {
     >&2 cat << EOF
 USAGE:
-    aws-quickstart [OPTIONS] -u XR_USERNAME -p XR_PASSWORD
+    aws-quickstart [OPTIONS] -u XR_USERNAME -p XR_PASSWORD -b BASTION_REMOTE_ACCESS_CIDR_BLOCKS
 
 EOF
 }
@@ -26,6 +26,9 @@ ARGS:
 
     -p, --password
            XR password.
+
+    -b, --bastion-remote-access-cidr-blocks
+           IPv4 CIDR blocks to allow SSH access to the Bastion instance.
 
 OPTIONS:
     -a, --ami
@@ -48,6 +51,7 @@ DESTROY=""
 KUBERNETES_VERSION="1.30"
 XR_USERNAME=""
 XR_PASSWORD=""
+BASTION_REMOTE_ACCESS_CIDR_BLOCKS=""
 
 # Parse the arguments
 while [ $# -gt 0 ]; do
@@ -58,6 +62,10 @@ while [ $# -gt 0 ]; do
       ;;
     -p|--password )
       XR_PASSWORD="$2"
+      shift
+      ;;
+    -b|--bastion-remote-access-cidr-blocks )
+      BASTION_REMOTE_ACCESS_CIDR_BLOCKS="$2"
       shift
       ;;
     -a|--ami )
@@ -86,6 +94,10 @@ if [ -z "${XR_USERNAME:-}" ] && [ -z "$DESTROY" ]; then
 fi
 if [ -z "${XR_PASSWORD:-}" ] && [ -z "$DESTROY" ]; then
   >&2 echo "error: XR password (-p|--password) must be specified"
+  ERROR=1
+fi
+if [ -z "${BASTION_REMOTE_ACCESS_CIDR_BLOCKS:-}" ] && [ -z "$DESTROY" ]; then
+  >&2 echo "error: Bastion remote access CIDR blocks (-b|--bastion-remote-access-cidr-blocks) must be specified"
   ERROR=1
 fi
 
@@ -144,9 +156,28 @@ terraform_apply () {
 
   trap terraform_destroy ERR EXIT
 
+  if [ "$BASTION_REMOTE_ACCESS_CIDR_BLOCKS" != "null" ]; then
+    # This script takes a comma-separated list as input, but Terraform wants
+    # this as a list of strings in HCL format.
+    #
+    # For example, we must convert:
+    #   10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    # to:
+    #   ["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+    #
+    # Do this in two steps:
+    #   Replace ',' with '","'.
+    #   Prepend '["', and append ']"'.
+    bastion_var_value="${BASTION_REMOTE_ACCESS_CIDR_BLOCKS/,/\",\"}"
+    bastion_var_value="[\"${bastion_var_value}\"]"
+  else
+    bastion_var_value="null"
+  fi
+
   terraform -chdir="$SCRIPT_DIR"/examples/bootstrap apply \
       -auto-approve \
-      -var "cluster_version=$KUBERNETES_VERSION"
+      -var "cluster_version=$KUBERNETES_VERSION" \
+      -var "bastion_remote_access_cidr_blocks=$bastion_var_value"
   terraform -chdir="$SCRIPT_DIR"/examples/overlay/infra apply \
       -auto-approve \
       ${AMI_ID:+"-var node_ami=$AMI_ID"}
@@ -166,7 +197,8 @@ terraform_destroy () {
   terraform -chdir="$SCRIPT_DIR"/examples/overlay/infra destroy \
       -auto-approve
   terraform -chdir="$SCRIPT_DIR"/examples/bootstrap destroy \
-      -auto-approve
+      -auto-approve \
+      -var "bastion_remote_access_cidr_blocks=null"
 }
 
 if [ -z "$DESTROY" ]; then

--- a/aws-quickstart
+++ b/aws-quickstart
@@ -166,9 +166,9 @@ terraform_apply () {
     #   ["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
     #
     # Do this in two steps:
-    #   Replace ',' with '","'.
-    #   Prepend '["', and append ']"'.
-    bastion_var_value="${BASTION_REMOTE_ACCESS_CIDR_BLOCKS/,/\",\"}"
+    #   Replace any ',' with '","'.
+    #   Prepend '["', and append '"]'.
+    bastion_var_value="${BASTION_REMOTE_ACCESS_CIDR_BLOCKS//,/\",\"}"
     bastion_var_value="[\"${bastion_var_value}\"]"
   else
     bastion_var_value="null"

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -41,7 +41,7 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
-| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance.<br>This must be a list of strings.<br>Pass 'null' to prevent access to the Bastion instance. | `list(string)` | n/a | yes |
+| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance.<br>This must be a list of strings.<br>If null, then access to the Bastion instance is prevented. | `list(string)` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.30"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -41,7 +41,7 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
-| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance | `list(string)` | n/a | yes |
+| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance.<br>This must be a list of strings. | `list(string)` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.30"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -41,6 +41,7 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
+| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance | `list(string)` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.30"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -41,7 +41,7 @@ terraform destroy
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
-| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance.<br>This must be a list of strings. | `list(string)` | n/a | yes |
+| <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance.<br>This must be a list of strings.<br>Pass 'null' to prevent access to the Bastion instance. | `list(string)` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.30"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 

--- a/examples/bootstrap/main.tf
+++ b/examples/bootstrap/main.tf
@@ -10,7 +10,8 @@ provider "aws" {
 module "bootstrap" {
   source = "../../modules/aws/bootstrap"
 
-  azs             = coalesce(var.azs, slice(data.aws_availability_zones.available.names, 0, 2))
-  cluster_version = var.cluster_version
-  name_prefix     = var.name_prefix
+  azs                               = coalesce(var.azs, slice(data.aws_availability_zones.available.names, 0, 2))
+  bastion_remote_access_cidr_blocks = var.bastion_remote_access_cidr_blocks
+  cluster_version                   = var.cluster_version
+  name_prefix                       = var.name_prefix
 }

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -24,7 +24,10 @@ variable "azs" {
 }
 
 variable "bastion_remote_access_cidr_blocks" {
-  description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
+  description = <<-EOT
+  Allowed CIDR blocks for external SSH access to the Bastion instance.
+  This must be a list of strings.
+  EOT
   type        = list(string)
   nullable    = false
 }

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -23,6 +23,12 @@ variable "azs" {
   }
 }
 
+variable "bastion_remote_access_cidr_blocks" {
+  description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
+  type        = list(string)
+  nullable    = false
+}
+
 variable "cluster_version" {
   description = "Cluster version"
   type        = string

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -27,9 +27,9 @@ variable "bastion_remote_access_cidr_blocks" {
   description = <<-EOT
   Allowed CIDR blocks for external SSH access to the Bastion instance.
   This must be a list of strings.
+  Pass 'null' to prevent access to the Bastion instance.
   EOT
   type        = list(string)
-  nullable    = false
 }
 
 variable "cluster_version" {

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -27,7 +27,7 @@ variable "bastion_remote_access_cidr_blocks" {
   description = <<-EOT
   Allowed CIDR blocks for external SSH access to the Bastion instance.
   This must be a list of strings.
-  Pass 'null' to prevent access to the Bastion instance.
+  If null, then access to the Bastion instance is prevented.
   EOT
   type        = list(string)
 }

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -29,6 +29,7 @@ variable "name" {
 variable "remote_access_cidr" {
   description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
   type        = list(string)
+  default     = []
   nullable    = false
 }
 

--- a/modules/aws/bastion/variables.tf
+++ b/modules/aws/bastion/variables.tf
@@ -29,7 +29,6 @@ variable "name" {
 variable "remote_access_cidr" {
   description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
   type        = list(string)
-  default     = ["0.0.0.0/0"]
   nullable    = false
 }
 

--- a/modules/aws/bootstrap/variables.tf
+++ b/modules/aws/bootstrap/variables.tf
@@ -9,7 +9,10 @@ variable "azs" {
 }
 
 variable "bastion_remote_access_cidr_blocks" {
-  description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
+  description = <<-EOT
+  Allowed CIDR blocks for external SSH access to the Bastion instance.
+  If null, then access to the Bastion instance is prevented.
+  EOT
   type        = list(string)
 }
 

--- a/modules/aws/bootstrap/variables.tf
+++ b/modules/aws/bootstrap/variables.tf
@@ -11,7 +11,6 @@ variable "azs" {
 variable "bastion_remote_access_cidr_blocks" {
   description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
   type        = list(string)
-  nullable    = false
 }
 
 variable "cluster_version" {

--- a/modules/aws/bootstrap/variables.tf
+++ b/modules/aws/bootstrap/variables.tf
@@ -11,7 +11,7 @@ variable "azs" {
 variable "bastion_remote_access_cidr_blocks" {
   description = "Allowed CIDR blocks for external SSH access to the Bastion instance"
   type        = list(string)
-  default     = null
+  nullable    = false
 }
 
 variable "cluster_version" {


### PR DESCRIPTION
Background:

- The Bastion module (responsible for bringing up the Bastion instance) exposes a `remote_access_cidr` variable.  This is a list of CIDRs that are allowed SSH access to the Bastion.
- The default is `["0.0.0.0/0"]`, which allows access from anywhere.
- This is re-exposed in the Bootstrap module, with the same default.
- So the default behavior for users of the Bootstrap configuration is that a Bastion instance is created that has unrestricted SSH access (other than normal RSA auth)

Modify this so that:

- There is no default value for `remote_access_cidr` in the Boostrap configuration.  This means that users of the Bootstrap configuration must provide a value for this.  This is a breaking change.
- This is considered a balance between:
  - More secure than defaulting to `0.0.0.0/0`
  - More usable than defaulting to restricting all access - a lot of the point of the Terraform configurations is that users can see how an XRd-capable EC2 node is setup.  If no-one can access the Bastion, then no-one can access the nodes.

If the user provides `null` explicitly, then access to the Bastion is prevented.

**The reviewer should consider whether the above is an appropriate balance of i. defaulting to security; ii. usability, both in terms of accessing the Bastion/nodes, and usability of the Terraform configuration given this is a new required variable.**

In the `aws-quickstart` script:

- Add a `-b|--bastion-remote-access-cidr-blocks` required argument.
- This should be a comma-separated list of CIDRs.
- If the user provides 'null', prevent access to the Bastion.

The implementation of the aws-quickstart script is slightly messy, and an area of focus for the reviewer.