### PR TITLE
Allow traffic from self in Bastion SG

### DIFF
--- a/modules/aws/bastion/main.tf
+++ b/modules/aws/bastion/main.tf
@@ -7,6 +7,16 @@ resource "aws_security_group" "this" {
   }
 }
 
+resource "aws_vpc_security_group_ingress_rule" "self" {
+  security_group_id = aws_security_group.this.id
+
+  description                  = "Ingress traffic from self"
+  referenced_security_group_id = aws_security_group.this.id
+  from_port                    = -1
+  to_port                      = -1
+  ip_protocol                  = -1
+}
+
 resource "aws_vpc_security_group_ingress_rule" "ssh" {
   for_each = toset(var.remote_access_cidr)
 


### PR DESCRIPTION
https://github.com/ios-xr/xrd-terraform/pull/22 added restrictions on the Bastion SG.

Some example configurations put the primary ENA of each EC2 instance in the Bastion SG.  This used to be fine for access - because the Bastion SG was open to everyone, so you could SSH to the Bastion, and then to the EC2 instance.

This is now not possible if you restrict traffic to the Bastion to certain CIDRs.  You can SSH to the Bastion, but you cannot then jump to the EC2 instance, because traffic no longer originates at the allowed CIDR.

Add an SGR to the Bastion SG to allow all traffic from itself.