### PR TITLE
Update cloud router requirements

### DIFF
--- a/dev/flex/templates/values-vrouter.yaml.tftpl
+++ b/dev/flex/templates/values-vrouter.yaml.tftpl
@@ -7,7 +7,7 @@ xrd${i + 1}:
     pullPolicy: Always
   resources:
     limits:
-      memory: 8Gi
+      memory: 10Gi
       hugepages-1Gi: ${hugepages[node_name]}Gi
   securityContext:
     privileged: true

--- a/examples/overlay/workload/templates/xrd1.yaml.tftpl
+++ b/examples/overlay/workload/templates/xrd1.yaml.tftpl
@@ -3,8 +3,8 @@ image:
   tag: "${image_tag}"
 resources:
   limits:
-    memory: 8Gi
-    hugepages-1Gi: 3Gi
+    memory: 10Gi
+    hugepages-1Gi: 6Gi
 persistence:
   enabled: true
   storageClass: gp2

--- a/examples/overlay/workload/templates/xrd2.yaml.tftpl
+++ b/examples/overlay/workload/templates/xrd2.yaml.tftpl
@@ -3,8 +3,8 @@ image:
   tag: "${image_tag}"
 resources:
   limits:
-    memory: 8Gi
-    hugepages-1Gi: 3Gi
+    memory: 10Gi
+    hugepages-1Gi: 6Gi
 persistence:
   enabled: true
   storageClass: gp2

--- a/examples/singleton/workload/templates/xrd-control-plane.yaml.tftpl
+++ b/examples/singleton/workload/templates/xrd-control-plane.yaml.tftpl
@@ -4,7 +4,6 @@ image:
 resources:
   limits:
     memory: 8Gi
-    hugepages-1Gi: 3Gi
 persistence:
   enabled: true
   storageClass: gp2

--- a/examples/singleton/workload/templates/xrd-vrouter.yaml.tftpl
+++ b/examples/singleton/workload/templates/xrd-vrouter.yaml.tftpl
@@ -3,8 +3,8 @@ image:
   tag: "${image_tag}"
 resources:
   limits:
-    memory: 8Gi
-    hugepages-1Gi: 3Gi
+    memory: 10Gi
+    hugepages-1Gi: 6Gi
 persistence:
   enabled: true
   storageClass: gp2

--- a/modules/aws/node-props/main.tf
+++ b/modules/aws/node-props/main.tf
@@ -3,12 +3,12 @@ locals {
     "cloud-router" = {
       "m5.2xlarge" = {
         cpuset       = "2-3"
-        hugepages_gb = 4
+        hugepages_gb = 6
       }
 
       "m5n.2xlarge" = {
         cpuset       = "2-3"
-        hugepages_gb = 4
+        hugepages_gb = 6
       }
 
       "m5.24xlarge" = {
@@ -129,7 +129,7 @@ locals {
 }
 
 locals {
-  minimal_hugepages_gb = 4
+  minimal_hugepages_gb = 6
   maximal_hugepages_gb = 6
 
   hugepages_gb = try(


### PR DESCRIPTION
Minimal cloud router should have 10GiB memory and 6GiB hugepages.

Scale cloud router should have 16GiB memory.

Changes:
- Update example XRd vRouter configurations (i.e. template Helm values files) to use 10GiB memory and 6GiB hugepages (i.e. representative of a minimal cloud router).
- Update the node-props module to return 6GiB hugepages for the minimal cloud router use case (cloud router on m5.2xlarge), and the "minimal" use case.  There's an argument that the minimal use case should use 3GiB hugepages instead - this was at 4GiB hugepages (I don't know where the 4GiB number came from).

Also fix the singleton XRd Control Plane example requesting hugepages.