### PR TITLE
Add bastion security group settings to data_interfaces

### DIFF
--- a/modules/aws/data-subnets/main.tf
+++ b/modules/aws/data-subnets/main.tf
@@ -16,6 +16,20 @@ resource "aws_security_group" "this" {
     self      = true
   }
 
+  ingress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = -1
+    security_groups = [var.bastion_security_group_id]
+  }
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = -1
+    security_groups = [var.bastion_security_group_id]
+  }
+
+
   tags = {
     Name = "${var.name_prefix}-data"
   }

--- a/modules/aws/data-subnets/main.tf
+++ b/modules/aws/data-subnets/main.tf
@@ -22,13 +22,13 @@ resource "aws_security_group" "this" {
     protocol        = -1
     security_groups = [var.bastion_security_group_id]
   }
+
   egress {
     from_port       = 0
     to_port         = 0
     protocol        = -1
     security_groups = [var.bastion_security_group_id]
   }
-
 
   tags = {
     Name = "${var.name_prefix}-data"

--- a/modules/aws/data-subnets/variables.tf
+++ b/modules/aws/data-subnets/variables.tf
@@ -21,3 +21,10 @@ variable "vpc_id" {
   type        = string
   nullable    = false
 }
+
+variable "bastion_security_group_id" {
+  description = "Number of subnets to create"
+  type        = string
+  nullable    = false
+}
+

--- a/modules/aws/data-subnets/variables.tf
+++ b/modules/aws/data-subnets/variables.tf
@@ -23,8 +23,7 @@ variable "vpc_id" {
 }
 
 variable "bastion_security_group_id" {
-  description = "Number of subnets to create"
+  description = "Id of the bastion security group"
   type        = string
   nullable    = false
 }
-

--- a/tests/ut/terraform/data-subnets/main.tf
+++ b/tests/ut/terraform/data-subnets/main.tf
@@ -5,15 +5,26 @@ provider "aws" {
   }
 }
 
+resource "aws_security_group" "bastion" {
+  name   = "bastion_security_group_id"
+  vpc_id = var.vpc_id
+}
+
 module "data_subnets" {
   source = "../../../../modules/aws/data-subnets"
 
-  availability_zone = var.availability_zone
-  name_prefix       = var.name_prefix
-  subnet_count      = var.subnet_count
-  vpc_id            = var.vpc_id
+  availability_zone         = var.availability_zone
+  name_prefix               = var.name_prefix
+  subnet_count              = var.subnet_count
+  vpc_id                    = var.vpc_id
+  bastion_security_group_id = aws_security_group.bastion.id
 }
 
 output "module" {
-  value = module.data_subnets
+  value = merge(
+    module.data_subnets,
+    {
+      "bastion_security_group_id" : aws_security_group.bastion.id
+    }
+  )
 }

--- a/tests/ut/test_data_subnets.py
+++ b/tests/ut/test_data_subnets.py
@@ -87,7 +87,7 @@ def test_subnet_count(
         assert sgr["Ipv6Ranges"] == []
         assert sgr["PrefixListIds"] == []
         assert len(sgr["UserIdGroupPairs"]) == 2
-        # Expect two different groups, one in basion security group and the
+        # Expect two different groups, one in bastion security group and the
         # other in its own security group.
         assert (
             {

--- a/tests/ut/test_data_subnets.py
+++ b/tests/ut/test_data_subnets.py
@@ -89,12 +89,10 @@ def test_subnet_count(
         assert len(sgr["UserIdGroupPairs"]) == 2
         # Expect two different groups, one in bastion security group and the
         # other in its own security group.
-        assert (
-            {
-                sgr["UserIdGroupPairs"][0]["GroupId"],
-                sgr["UserIdGroupPairs"][1]["GroupId"],
-            } == {
-                outputs.security_group_id,
-                outputs.bastion_security_group_id,
-            }
-        )
+        assert {
+            sgr["UserIdGroupPairs"][0]["GroupId"],
+            sgr["UserIdGroupPairs"][1]["GroupId"],
+        } == {
+            outputs.security_group_id,
+            outputs.bastion_security_group_id,
+        }

--- a/tests/ut/test_data_subnets.py
+++ b/tests/ut/test_data_subnets.py
@@ -18,6 +18,7 @@ class Outputs(TerraformOutputs):
     ids: dict[str, str]
     names: list[str]
     security_group_id: str
+    bastion_security_group_id: str
 
 
 @pytest.fixture(scope="module")
@@ -85,7 +86,15 @@ def test_subnet_count(
         assert sgr["IpRanges"] == []
         assert sgr["Ipv6Ranges"] == []
         assert sgr["PrefixListIds"] == []
-        assert len(sgr["UserIdGroupPairs"]) == 1
+        assert len(sgr["UserIdGroupPairs"]) == 2
+        # Expect two different groups, one in basion security group and the
+        # other in its own security group.
         assert (
-            sgr["UserIdGroupPairs"][0]["GroupId"] == outputs.security_group_id
+            {
+                sgr["UserIdGroupPairs"][0]["GroupId"],
+                sgr["UserIdGroupPairs"][1]["GroupId"],
+            } == {
+                outputs.security_group_id,
+                outputs.bastion_security_group_id,
+            }
         )


### PR DESCRIPTION
Required since EKS v1.30 to allow access to the data interfaces from the bastion.

data_subnet UT updated for this change.