### PR TITLE
Remove references to K8s v1.23

### DIFF
--- a/aws-quickstart
+++ b/aws-quickstart
@@ -40,7 +40,7 @@ OPTIONS:
             Destroy the workload and infrastructure.
 
     --kubernetes-version
-            Kubernetes version to use.  This must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30, 1.31
+            Kubernetes version to use.  This must be one of: 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30, 1.31
             (default: 1.31).
 EOF
 }
@@ -101,8 +101,7 @@ if [ -z "${BASTION_REMOTE_ACCESS_CIDR_BLOCKS:-}" ] && [ -z "$DESTROY" ]; then
   ERROR=1
 fi
 
-if [ "${KUBERNETES_VERSION}" != "1.23" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.24" ] &&
+if [ "${KUBERNETES_VERSION}" != "1.24" ] &&
    [ "${KUBERNETES_VERSION}" != "1.25" ] &&
    [ "${KUBERNETES_VERSION}" != "1.26" ] &&
    [ "${KUBERNETES_VERSION}" != "1.27" ] &&
@@ -110,7 +109,7 @@ if [ "${KUBERNETES_VERSION}" != "1.23" ] &&
    [ "${KUBERNETES_VERSION}" != "1.29" ] &&
    [ "${KUBERNETES_VERSION}" != "1.30" ] &&
    [ "${KUBERNETES_VERSION}" != "1.31" ]; then
-    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30, 1.31"
+    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.30, 1.31"
     ERROR=1
 fi
 

--- a/tests/ut/test_eks.py
+++ b/tests/ut/test_eks.py
@@ -124,7 +124,6 @@ def test_defaults(
 @pytest.mark.parametrize(
     "cluster_version",
     (
-        "1.23",
         "1.24",
         "1.25",
         "1.26",


### PR DESCRIPTION
Version is no longer supported in AWS, see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html for currently supported versions.