### PR TITLE
Add terraform to ubuntu image used to run commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: hashicorp/setup-terraform@v3
+        with:
+            terraform_version: "^1.3.7"
+            terraform_wrapper: false
+
       - name: "Setup prerequisites"
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,8 +19,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-            terraform_version: "^1.3.7"
-            terraform_wrapper: false
+          terraform_version: "1.7.1"
 
       - name: "Setup prerequisites"
         # yamllint disable rule:line-length


### PR DESCRIPTION
Terraform has been removed from ubuntu:latest image.