### PR TITLE
Update number of CPU cores in node props

### DIFF
--- a/modules/aws/node-props/main.tf
+++ b/modules/aws/node-props/main.tf
@@ -12,12 +12,17 @@ locals {
       }
 
       "m5.24xlarge" = {
-        cpuset       = "12-23"
+        cpuset       = "7-23"
         hugepages_gb = 6
       }
 
       "m5n.24xlarge" = {
-        cpuset       = "12-23"
+        cpuset       = "7-23"
+        hugepages_gb = 6
+      }
+
+      "m6in.16xlarge" = {
+        cpuset       = "15-31"
         hugepages_gb = 6
       }
     }


### PR DESCRIPTION
Update the number of CPU cores to use in node props:

* m5n.24xlarge and m5.24xlarge increase to 17 cores from 12
* m6in.16xlarge added, with 17 cores

Verified manually that this gives correct isolated cores on m6in.16xlarge and m5n.24xlarge.