### PR TITLE
donePin TF Helm plugin version to less than 3.0

### DIFF
--- a/dev/flex/versions.tf
+++ b/dev/flex/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {

--- a/examples/ha/infra/versions.tf
+++ b/examples/ha/infra/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {

--- a/examples/ha/workload/versions.tf
+++ b/examples/ha/workload/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {

--- a/examples/overlay/infra/versions.tf
+++ b/examples/overlay/infra/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {

--- a/examples/overlay/workload/versions.tf
+++ b/examples/overlay/workload/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {

--- a/examples/singleton/infra/versions.tf
+++ b/examples/singleton/infra/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {

--- a/examples/singleton/workload/versions.tf
+++ b/examples/singleton/workload/versions.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.9"
+      version = "~> 2.9, < 3.0"
     }
 
     kubernetes = {


### PR DESCRIPTION
Pin TF Helm plugin version to less than 3.0 as new syntax change is incompatible with our TF.

See https://github.com/hashicorp/terraform-provider-helm/releases

Covered by pre-commit checks.