### PR TITLE
Remove EKS 1.26 and 1.27 versions

### DIFF
--- a/aws-quickstart
+++ b/aws-quickstart
@@ -40,7 +40,7 @@ OPTIONS:
             Destroy the workload and infrastructure.
 
     --kubernetes-version
-            Kubernetes version to use.  This must be one of: 1.26, 1.27, 1.28, 1.29, 1.30, 1.31, 1.32, 1.33
+            Kubernetes version to use.  This must be one of: 1.28, 1.29, 1.30, 1.31, 1.32, 1.33
             (default: 1.33).
 EOF
 }
@@ -101,15 +101,13 @@ if [ -z "${BASTION_REMOTE_ACCESS_CIDR_BLOCKS:-}" ] && [ -z "$DESTROY" ]; then
   ERROR=1
 fi
 
-if [ "${KUBERNETES_VERSION}" != "1.26" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.27" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.28" ] &&
+if [ "${KUBERNETES_VERSION}" != "1.28" ] &&
    [ "${KUBERNETES_VERSION}" != "1.29" ] &&
    [ "${KUBERNETES_VERSION}" != "1.30" ] &&
    [ "${KUBERNETES_VERSION}" != "1.31" ] &&
    [ "${KUBERNETES_VERSION}" != "1.32" ] &&
    [ "${KUBERNETES_VERSION}" != "1.33" ]; then
-    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.26, 1.27, 1.28, 1.29, 1.30, 1.31, 1.32, 1.33"
+    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.28, 1.29, 1.30, 1.31, 1.32, 1.33"
     ERROR=1
 fi
 

--- a/tests/ut/test_eks.py
+++ b/tests/ut/test_eks.py
@@ -124,8 +124,6 @@ def test_defaults(
 @pytest.mark.parametrize(
     "cluster_version",
     (
-        "1.26",
-        "1.27",
         "1.28",
         "1.29",
         "1.30",


### PR DESCRIPTION
They are both EOL as of 24 Jul 25: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html