### PR TITLE
Add EKS v1.34 support

### DIFF
--- a/aws-quickstart
+++ b/aws-quickstart
@@ -40,15 +40,15 @@ OPTIONS:
             Destroy the workload and infrastructure.
 
     --kubernetes-version
-            Kubernetes version to use.  This must be one of: 1.28, 1.29, 1.30, 1.31, 1.32, 1.33
-            (default: 1.33).
+            Kubernetes version to use.  This must be one of: 1.29, 1.30, 1.31, 1.32, 1.33, 1.34
+            (default: 1.34).
 EOF
 }
 
 # Default arguments.
 AMI_ID=""
 DESTROY=""
-KUBERNETES_VERSION="1.33"
+KUBERNETES_VERSION="1.34"
 XR_USERNAME=""
 XR_PASSWORD=""
 BASTION_REMOTE_ACCESS_CIDR_BLOCKS=""
@@ -101,13 +101,13 @@ if [ -z "${BASTION_REMOTE_ACCESS_CIDR_BLOCKS:-}" ] && [ -z "$DESTROY" ]; then
   ERROR=1
 fi
 
-if [ "${KUBERNETES_VERSION}" != "1.28" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.29" ] &&
+if [ "${KUBERNETES_VERSION}" != "1.29" ] &&
    [ "${KUBERNETES_VERSION}" != "1.30" ] &&
    [ "${KUBERNETES_VERSION}" != "1.31" ] &&
    [ "${KUBERNETES_VERSION}" != "1.32" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.33" ]; then
-    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.28, 1.29, 1.30, 1.31, 1.32, 1.33"
+   [ "${KUBERNETES_VERSION}" != "1.33" ] &&
+   [ "${KUBERNETES_VERSION}" != "1.34" ]; then
+    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.29, 1.30, 1.31, 1.32, 1.33, 1.34"
     ERROR=1
 fi
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -42,7 +42,7 @@ terraform destroy
 |------|-------------|------|---------|:--------:|
 | <a name="input_azs"></a> [azs](#input\_azs) | List of exactly two availability zones in the currently configured AWS region.<br>A private subnet and a public subnet is created in each of these availability zones.<br>Each cluster node is launched in one of the private subnets.<br>If null, then the first two availability zones in the currently configured AWS region is used. | `list(string)` | `null` | no |
 | <a name="input_bastion_remote_access_cidr_blocks"></a> [bastion\_remote\_access\_cidr\_blocks](#input\_bastion\_remote\_access\_cidr\_blocks) | Allowed CIDR blocks for external SSH access to the Bastion instance.<br>This must be a list of strings.<br>If null, then access to the Bastion instance is prevented. | `list(string)` | n/a | yes |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.33"` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Cluster version | `string` | `"1.34"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Used as a prefix for the 'Name' tag for each created resource.<br>If null, then a random name 'xrd-terraform-[0-9a-z]{8}' is used. | `string` | `null` | no |
 
 ## Outputs

--- a/examples/bootstrap/variables.tf
+++ b/examples/bootstrap/variables.tf
@@ -35,6 +35,6 @@ variable "bastion_remote_access_cidr_blocks" {
 variable "cluster_version" {
   description = "Cluster version"
   type        = string
-  default     = "1.33"
+  default     = "1.34"
   nullable    = false
 }

--- a/tests/ut/test_eks.py
+++ b/tests/ut/test_eks.py
@@ -101,7 +101,7 @@ def security_group(ec2: EC2ServiceResource, vpc: Vpc) -> SecurityGroup:
 @pytest.fixture
 def base_vars(subnet1: Subnet, subnet2: Subnet) -> dict[str, Any]:
     return {
-        "cluster_version": "1.33",
+        "cluster_version": "1.34",
         "name": str(uuid.uuid4()),
         "subnet_ids": [subnet1.id, subnet2.id],
     }
@@ -124,11 +124,12 @@ def test_defaults(
 @pytest.mark.parametrize(
     "cluster_version",
     (
-        "1.28",
         "1.29",
         "1.30",
         "1.31",
         "1.32",
+        "1.33",
+        "1.34",
     ),
 )
 def test_cluster_version(


### PR DESCRIPTION
Add support for EKS v1.34, and remove support for EKS v1.28 (which is EOL):
 - `aws-quickstart` script updated to allow 1.34, and no longer support 1.28.
 - Default version used by the `eks-cluster` module is changed 1.34.
 - MUT updated appropriately.