### PR TITLE
Remove EKS 1.29 version

### DIFF
--- a/aws-quickstart
+++ b/aws-quickstart
@@ -40,7 +40,7 @@ OPTIONS:
             Destroy the workload and infrastructure.
 
     --kubernetes-version
-            Kubernetes version to use.  This must be one of: 1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35
+            Kubernetes version to use.  This must be one of: 1.30, 1.31, 1.32, 1.33, 1.34, 1.35
             (default: 1.35).
 EOF
 }
@@ -101,14 +101,13 @@ if [ -z "${BASTION_REMOTE_ACCESS_CIDR_BLOCKS:-}" ] && [ -z "$DESTROY" ]; then
   ERROR=1
 fi
 
-if [ "${KUBERNETES_VERSION}" != "1.29" ] &&
-   [ "${KUBERNETES_VERSION}" != "1.30" ] &&
+if [ "${KUBERNETES_VERSION}" != "1.30" ] &&
    [ "${KUBERNETES_VERSION}" != "1.31" ] &&
    [ "${KUBERNETES_VERSION}" != "1.32" ] &&
    [ "${KUBERNETES_VERSION}" != "1.33" ] &&
    [ "${KUBERNETES_VERSION}" != "1.34" ] &&
    [ "${KUBERNETES_VERSION}" != "1.35" ]; then
-    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35"
+    >&2 echo "error: Kubernetes version (--kubernetes-version) must be one of: 1.30, 1.31, 1.32, 1.33, 1.34, 1.35"
     ERROR=1
 fi
 

--- a/tests/ut/test_eks.py
+++ b/tests/ut/test_eks.py
@@ -124,7 +124,6 @@ def test_defaults(
 @pytest.mark.parametrize(
     "cluster_version",
     (
-        "1.29",
         "1.30",
         "1.31",
         "1.32",


### PR DESCRIPTION
This version is EOL according to https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html